### PR TITLE
Docs: add README standard

### DIFF
--- a/docs/readme-deprecated-standard.md
+++ b/docs/readme-deprecated-standard.md
@@ -1,0 +1,75 @@
+# Contributte Deprecated Repository README Standard
+
+## Scope
+
+This standard applies to libraries and projects that are archived, abandoned, superseded, or no longer supported. Their README is a truthful maintenance notice, not an attempt to preserve a current onboarding path.
+
+Use this profile before archiving a repository and whenever a repository's current README implies active support that no longer exists.
+
+## Required information
+
+A deprecated README MUST begin with a visible H1 and an unambiguous status notice near the top. The notice MUST state:
+
+1. That the repository is deprecated, abandoned, archived, or unsupported.
+2. Whether security fixes, compatibility fixes, or releases are still provided.
+3. The recommended replacement, successor, or migration path when one exists.
+4. What users should do when no supported replacement exists.
+
+Use this default structure:
+
+```md
+# Package Name
+
+> [!WARNING]
+> This package is no longer maintained. No releases, compatibility fixes, or
+> security updates are planned.
+
+## Replacement
+
+## Existing installations
+
+## Historical documentation
+
+## License
+```
+
+Use an appropriate GitHub alert level:
+
+- `WARNING` for a maintained migration path or a package that should not be selected for new work.
+- `CAUTION` when the package has known security, data-loss, or operational risk.
+- `NOTE` only for a planned future deprecation that does not yet change support.
+
+## Replacement and migration
+
+When a successor exists, link directly to its canonical repository, package, or migration guide. State whether APIs/configuration are compatible, require migration, or are unrelated. Do not claim drop-in compatibility without verification.
+
+When no replacement exists, say so plainly. Link to stable historical release documentation only when it remains useful for existing installations. Do not direct users to generic organization pages, issue trackers, or unmaintained forks as if they were supported replacements.
+
+## Existing installations
+
+Do not remove historical installation or configuration information needed to operate an existing deployment unless an owned archived documentation location retains it. Clearly separate it from new-project guidance:
+
+```md
+## Existing installations
+
+The following instructions are retained for deployments already using this package.
+They are not supported for new projects.
+```
+
+Remove or label stale requirements, badges, CI claims, demo links, social channels, and screenshots that suggest active maintenance. Never leave a current-looking `composer require` path at the top without the deprecation warning.
+
+## Security and ownership
+
+Do not promise security support unless a maintainer has explicitly committed to it. If the repository is abandoned because of a security concern, state the safe action first and use a `CAUTION` alert.
+
+Keep the original license and attribution. Do not add real secrets, private contact details, or unsupported operational guarantees.
+
+## Archival checklist
+
+- [ ] README status notice is visible before installation or usage material.
+- [ ] Support and security posture is explicit and truthful.
+- [ ] Replacement or absence of replacement is clear.
+- [ ] Existing-installation documentation is separated from new-project guidance.
+- [ ] Stale badges, demos, and contact/support links do not imply active maintenance.
+- [ ] Local historical links resolve and Markdown renders correctly on GitHub.
+- [ ] Repository description, topics, and GitHub archive state agree with the README when repository administration is in scope.

--- a/docs/readme-deprecated-standard.md
+++ b/docs/readme-deprecated-standard.md
@@ -1,10 +1,26 @@
 # Contributte Deprecated Repository README Standard
 
+## Profiles
+
+[Overview](readme-standard.md) | [Library](readme-library-standard.md) | [Skeleton](readme-skeleton-standard.md) | [Deprecated](readme-deprecated-standard.md)
+
 ## Scope
 
 This standard applies to libraries and projects that are archived, abandoned, superseded, or no longer supported. Their README is a truthful maintenance notice, not an attempt to preserve a current onboarding path.
 
 Use this profile before archiving a repository and whenever a repository's current README implies active support that no longer exists.
+
+## Writing style
+
+Write concise, factual developer-facing English. Prefer concrete subjects, verbs, package names, versions, support terms, and migration outcomes. Preserve accurate project terminology, product names, and established public wording; this standard does not require stylistic rewriting when existing language is clearer or more precise.
+
+In this standard, "factual" means verifiable from the repository, released package, or documented support policy. "Concrete" means naming the relevant replacement, version, support status, or action. "Clear" means a reader can identify the maintenance state and next action without promotional or implied claims.
+
+Prefer: `No supported replacement is available.`
+
+Avoid: `This project is old and should probably not be used.`
+
+Examples illustrate the required information; they are not mandatory wording. Keep project-specific terminology where it is accurate and understandable.
 
 ## Required information
 
@@ -43,7 +59,7 @@ Use an appropriate GitHub alert level:
 
 When a successor exists, link directly to its canonical repository, package, or migration guide. State whether APIs/configuration are compatible, require migration, or are unrelated. Do not claim drop-in compatibility without verification.
 
-When no replacement exists, say so plainly. Link to stable historical release documentation only when it remains useful for existing installations. Do not direct users to generic organization pages, issue trackers, or unmaintained forks as if they were supported replacements.
+When no replacement exists, state `No supported replacement is available.` Link to stable historical release documentation only when it remains useful for existing installations. Do not direct users to generic organization pages, issue trackers, or unmaintained forks as if they were supported replacements.
 
 ## Existing installations
 
@@ -56,6 +72,8 @@ The following instructions are retained for deployments already using this packa
 They are not supported for new projects.
 ```
 
+When known, provide an actionable maintenance boundary for existing deployments: the final supported release or version, the retained documentation location, and a statement that the material is historical and receives no support, compatibility fixes, or security updates. This does not promise a migration guide or ongoing support.
+
 Remove or label stale requirements, badges, CI claims, demo links, social channels, and screenshots that suggest active maintenance. Never leave a current-looking `composer require` path at the top without the deprecation warning.
 
 ## Security and ownership
@@ -67,9 +85,11 @@ Keep the original license and attribution. Do not add real secrets, private cont
 ## Archival checklist
 
 - [ ] README status notice is visible before installation or usage material.
+- [ ] H1 and GitHub alert level accurately communicate the maintenance and risk status.
 - [ ] Support and security posture is explicit and truthful.
 - [ ] Replacement or absence of replacement is clear.
 - [ ] Existing-installation documentation is separated from new-project guidance.
 - [ ] Stale badges, demos, and contact/support links do not imply active maintenance.
 - [ ] Local historical links resolve and Markdown renders correctly on GitHub.
+- [ ] Historical material is clearly retained only for existing installations; license and attribution remain intact.
 - [ ] Repository description, topics, and GitHub archive state agree with the README when repository administration is in scope.

--- a/docs/readme-library-standard.md
+++ b/docs/readme-library-standard.md
@@ -1,8 +1,24 @@
 # Contributte Library README Standard
 
+## Profiles
+
+[Overview](readme-standard.md) | [Library](readme-library-standard.md) | [Skeleton](readme-skeleton-standard.md) | [Deprecated](readme-deprecated-standard.md)
+
 ## Scope
 
 This standard applies to maintained reusable Composer packages. A library README is a concise landing page: it identifies the package, gives a safe installation and first-use path, states relevant compatibility, and directs readers to maintained detailed documentation.
+
+## Writing style
+
+Write concise, factual developer-facing English. Prefer concrete subjects, verbs, commands, paths, versions, and observable outcomes. Preserve accurate project terminology, product names, command output, and established public wording; this standard does not require stylistic rewriting when existing language is clearer or more precise.
+
+In this standard, "factual" means verifiable from the repository, released package, or documented support policy. "Concrete" means naming the relevant command, path, version, URL, setting, or expected result. "Clear" means a reader can identify the action and outcome without promotional or implied claims.
+
+Prefer: `Run composer require contributte/foo to install the package.`
+
+Avoid: `This package makes integration effortless.`
+
+Examples illustrate the required information; they are not mandatory wording. Keep project-specific terminology where it is accurate and understandable.
 
 ## Required information
 
@@ -11,7 +27,7 @@ A library README MUST provide:
 1. A visible H1 and one factual sentence describing the package and its primary integration.
 2. The published Composer package name and a copyable installation command.
 3. The required framework, DI, runtime, or configuration entry point.
-4. A minimal valid use/configuration path, or a direct link to the exact maintained documentation page containing it.
+4. A minimal supported path through required wiring, configuration, first public use, and its observable result.
 5. Compatibility information when consumers must choose between maintained PHP, framework, package, or integration lines.
 6. A development or contribution route when the repository is maintained.
 
@@ -26,16 +42,20 @@ One factual sentence describing the package and its primary integration.
 
 ## Quick start
 
-## Documentation
+## Documentation (when separate detailed documentation exists)
 
 ## Supported versions
 
 ## Development
 ```
 
+Heading names and section boundaries MAY vary when the required information remains discoverable in the same reader order. A combined `Installation` section MAY contain the minimal first-use configuration; do not create an empty `Quick start` or `Documentation` section solely to match this outline.
+
 Use `Installation` for `composer require`; do not call installation-only content `Usage`. A development-only package MAY use `composer require --dev`, but it MUST say why.
 
-For Nette integrations, the first-use path MUST include required extension registration or NEON configuration when installation alone does not make the package usable. Do not show internal service IDs as normal configuration unless they are documented public extension points.
+The README MUST contain the complete minimal path through installation, the first required wiring step, the smallest valid configuration, one public use, and its observable result. For Nette integrations, this includes required extension registration or NEON configuration when installation alone does not make the package usable. Configuration alone is not a successful use: show a public service, Latte extension, command, response, rendered output, or other effect. When additional configuration is required for variants, link directly to the exact maintained documentation section; a link only to a documentation directory is insufficient. Do not show internal service IDs as normal configuration unless they are documented public extension points.
+
+`Quick start` is one vertical slice: required activation/configuration plus the smallest public use that demonstrates successful integration. It MUST NOT become an option reference, provider inventory, migration guide, or collection of unrelated tutorials. A library with independently useful settings MAY add `## Configuration` before `## Documentation`.
 
 ## Documentation boundary
 
@@ -45,13 +65,19 @@ The root README and repository-local detailed documentation are complementary:
 - Keep exhaustive schemas, API inventories, provider lists, migration history, and long tutorials in focused documentation.
 - Use relative links, for example `[Documentation](.docs/)` or a direct topic link.
 
-A small library MAY keep its full manual in the README when it remains the practical canonical documentation and is navigable.
+If detailed repository documentation exists, the README MUST contain a `## Documentation` section naming one canonical landing page or exact first-use page. A README topic list is not a substitute unless the README itself is intentionally the canonical detailed manual.
+
+A small library MAY keep its full manual in the README when it is the maintained primary documentation and its sections are easy to locate.
+
+When `.docs/README.md` is the established detailed-documentation index, retain it and link to it from the root README. Do not delete the index or move its full reference content into the root README merely to consolidate files.
 
 ## Compatibility and examples
 
-State requirements near installation when a support decision is non-obvious. Use a compact support matrix only when multiple maintained lines or integrations require it. Matrix values MUST match package constraints, tested CI, and release policy.
+Put minimum PHP, framework, and runtime requirements with Installation. Put `## Supported versions` after `## Documentation` by default. Add a compatibility section only when users must select among multiple maintained release or integration lines; a maintained line still receives releases, compatibility fixes, or security fixes. Do not repeat the same support data in both places. Matrix values MUST match package constraints, tested CI, and release policy.
 
 Each primary example MUST be syntactically valid, focused on one outcome, and introduced with where it belongs. Use typed code fences. Prefer constructor injection and current project conventions over legacy public-property injection or PHPDoc-heavy pseudo-code.
+
+Dev-only packages MUST state that they belong in development/test/static-analysis dependencies, use `composer require --dev`, show the command to run after installation, and state the expected successful result. Visual or multi-provider libraries MUST show one canonical provider or data source and a visible result; provider matrices and advanced modes belong in detailed documentation.
 
 ## Links, badges, and images
 
@@ -59,22 +85,26 @@ Use relative links for repository-owned documentation and assets. Do not use `bl
 
 Badges are optional. If used, keep them compact and actionable: CI, package version, PHP support, license, or live coverage. Use the actual Packagist package name, which may differ from the repository name. Every image needs useful alternative text.
 
-Images are optional. Include a repository-owned image only when it demonstrates a meaningful UI, CLI, or result. Headless integrations generally need a clear example more than a screenshot.
+Images are optional. Include a repository-owned image only when it shows an output or interaction that the written example cannot show clearly. Headless integrations generally need a clear example more than a screenshot.
 
 Do not add a manual table of contents to a short landing page. It MAY be useful for a long README with several independently useful areas; keep it shallow and maintained.
 
 ## Development and review
 
-Document canonical quality and test commands when the repository provides them. Prefer project entrypoints such as `make qa`, `make tests`, or Composer scripts. Describe commands accurately.
+Document canonical quality and test commands when the repository provides them. Prefer project entrypoints such as `make qa`, `make tests`, or Composer scripts. Describe commands accurately. A maintained repository MUST provide a contributor route: prefer a repository-local `CONTRIBUTING.md`; otherwise link to applicable maintained organization guidance.
+
+Place `## Development` after consumer documentation. Optional maintainer attribution, sponsorship, community, or support material MAY follow as a short footer; it MUST NOT interrupt installation, quick start, documentation, or compatibility information. A `## License` section or a clear link to the tracked license SHOULD appear near the end when the license is not otherwise evident.
 
 When a change affects installation, configuration, supported versions, commands, public endpoints, or images, update the README and detailed documentation in the same pull request.
 
 Review before merge:
 
 - [ ] H1, purpose, package name, and install command are correct.
-- [ ] Required Nette/framework wiring is shown or directly linked.
+- [ ] The first usable path includes required wiring and has an exact next-step link when more configuration is needed.
+- [ ] The primary example is checked against the current public API and states an observable successful result.
 - [ ] Requirements and support data match package metadata, CI, and release policy.
 - [ ] Examples are valid, typed, current, and use public supported interfaces.
 - [ ] The README remains onboarding material and has one canonical detailed-docs location.
+- [ ] The contributor route and canonical development commands are accurate.
 - [ ] Links, assets, badges, and images resolve and are maintained.
 - [ ] Markdown renders correctly on GitHub.

--- a/docs/readme-library-standard.md
+++ b/docs/readme-library-standard.md
@@ -1,0 +1,80 @@
+# Contributte Library README Standard
+
+## Scope
+
+This standard applies to maintained reusable Composer packages. A library README is a concise landing page: it identifies the package, gives a safe installation and first-use path, states relevant compatibility, and directs readers to maintained detailed documentation.
+
+## Required information
+
+A library README MUST provide:
+
+1. A visible H1 and one factual sentence describing the package and its primary integration.
+2. The published Composer package name and a copyable installation command.
+3. The required framework, DI, runtime, or configuration entry point.
+4. A minimal valid use/configuration path, or a direct link to the exact maintained documentation page containing it.
+5. Compatibility information when consumers must choose between maintained PHP, framework, package, or integration lines.
+6. A development or contribution route when the repository is maintained.
+
+Use this order as a default, omitting sections that are not useful:
+
+```md
+# Package Name
+
+One factual sentence describing the package and its primary integration.
+
+## Installation
+
+## Quick start
+
+## Documentation
+
+## Supported versions
+
+## Development
+```
+
+Use `Installation` for `composer require`; do not call installation-only content `Usage`. A development-only package MAY use `composer require --dev`, but it MUST say why.
+
+For Nette integrations, the first-use path MUST include required extension registration or NEON configuration when installation alone does not make the package usable. Do not show internal service IDs as normal configuration unless they are documented public extension points.
+
+## Documentation boundary
+
+The root README and repository-local detailed documentation are complementary:
+
+- Keep purpose, installation, compatibility, the minimal integration path, and development entrypoints in `README.md`.
+- Keep exhaustive schemas, API inventories, provider lists, migration history, and long tutorials in focused documentation.
+- Use relative links, for example `[Documentation](.docs/)` or a direct topic link.
+
+A small library MAY keep its full manual in the README when it remains the practical canonical documentation and is navigable.
+
+## Compatibility and examples
+
+State requirements near installation when a support decision is non-obvious. Use a compact support matrix only when multiple maintained lines or integrations require it. Matrix values MUST match package constraints, tested CI, and release policy.
+
+Each primary example MUST be syntactically valid, focused on one outcome, and introduced with where it belongs. Use typed code fences. Prefer constructor injection and current project conventions over legacy public-property injection or PHPDoc-heavy pseudo-code.
+
+## Links, badges, and images
+
+Use relative links for repository-owned documentation and assets. Do not use `blob/master` URLs for files in the same repository. Use absolute HTTPS URLs for external resources, Packagist, canonical hosted documentation, and maintained public demos.
+
+Badges are optional. If used, keep them compact and actionable: CI, package version, PHP support, license, or live coverage. Use the actual Packagist package name, which may differ from the repository name. Every image needs useful alternative text.
+
+Images are optional. Include a repository-owned image only when it demonstrates a meaningful UI, CLI, or result. Headless integrations generally need a clear example more than a screenshot.
+
+Do not add a manual table of contents to a short landing page. It MAY be useful for a long README with several independently useful areas; keep it shallow and maintained.
+
+## Development and review
+
+Document canonical quality and test commands when the repository provides them. Prefer project entrypoints such as `make qa`, `make tests`, or Composer scripts. Describe commands accurately.
+
+When a change affects installation, configuration, supported versions, commands, public endpoints, or images, update the README and detailed documentation in the same pull request.
+
+Review before merge:
+
+- [ ] H1, purpose, package name, and install command are correct.
+- [ ] Required Nette/framework wiring is shown or directly linked.
+- [ ] Requirements and support data match package metadata, CI, and release policy.
+- [ ] Examples are valid, typed, current, and use public supported interfaces.
+- [ ] The README remains onboarding material and has one canonical detailed-docs location.
+- [ ] Links, assets, badges, and images resolve and are maintained.
+- [ ] Markdown renders correctly on GitHub.

--- a/docs/readme-skeleton-standard.md
+++ b/docs/readme-skeleton-standard.md
@@ -1,8 +1,24 @@
 # Contributte Skeleton README Standard
 
+## Profiles
+
+[Overview](readme-standard.md) | [Library](readme-library-standard.md) | [Skeleton](readme-skeleton-standard.md) | [Deprecated](readme-deprecated-standard.md)
+
 ## Scope
 
-This standard applies to starters, reference applications, demos, and integration projects. A skeleton README is the shortest reliable route from discovery to a verified local success.
+This standard applies to starters, reference applications, demos, and integration projects. A skeleton README is a concise, complete route from obtaining the project to verifying it locally.
+
+## Writing style
+
+Write concise, factual developer-facing English. Prefer concrete subjects, verbs, commands, paths, versions, and observable outcomes. Preserve accurate project terminology, product names, command output, and established public wording; this standard does not require stylistic rewriting when existing language is clearer or more precise.
+
+In this standard, "factual" means verifiable from the repository, released package, or documented support policy. "Concrete" means naming the relevant command, path, version, URL, setting, or expected result. "Clear" means a reader can identify the action and outcome without promotional or implied claims.
+
+Prefer: `Open http://localhost:8080/health; it returns {"status":"ok"}.`
+
+Avoid: `Open the application and enjoy.`
+
+Examples illustrate the required information; they are not mandatory wording. Keep project-specific terminology where it is accurate and understandable.
 
 ## Required information
 
@@ -14,6 +30,8 @@ A skeleton README MUST state whether it is a starter, reference application, dem
 4. Required services, migrations, fixtures, or builds.
 5. Application, API, CLI, or protocol startup.
 6. A URL, request, command output, or client interaction that proves success.
+
+The README MUST begin with a single H1 followed immediately by a factual sentence that identifies the repository as a starter, reference application, demo, or integration demonstration. A `Purpose` section may expand this but MUST NOT be the first declaration of project type.
 
 Use this order as a default, omitting irrelevant sections:
 
@@ -37,17 +55,31 @@ One factual sentence describing the intended use and defining integrations.
 ## Further documentation
 ```
 
+Heading names and section boundaries MAY vary when the required information remains discoverable in the same reader order. `Quick start` MAY include the minimum local configuration and runtime commands when that is the complete recommended route; use a separate `Configuration` section when readers need it independently.
+
+The first reader-facing onboarding path MUST preserve execution order: requirements, acquisition, dependency installation and any required local configuration, backing services/data/assets, runtime, then verification. Later operational sections MUST NOT be required to complete an earlier Quick start.
+
 The README MUST distinguish acquisition models:
 
 - A consumer-ready starter uses `composer create-project`.
 - A checked-out example or integration uses `composer install`.
 - Document both only when both workflows are supported and their purposes are clear.
 
+A starter's Quick start MUST use `composer create-project` or an equivalent acquisition path. A checked-out reference or demo MUST state clone/template acquisition before `composer install` or `npm ci`. A consumer-ready starter MUST NOT present `composer install` alone as its acquisition route.
+
 ## Configuration and runtime paths
+
+The recommended route MUST have been run against the current tracked repository state and SHOULD be covered by an automated smoke or integration check when practical. Mark one route as recommended. Alternative host, Docker, or production-like routes MAY follow it and MUST identify their differing prerequisites, commands, ports, and success signal.
 
 Document the minimum configuration needed for the recommended path: config file/environment source, local or gitignored status, values that must change, and values that differ in containers. Label demo credentials as development-only.
 
 Document Docker only when it is a supported or recommended onboarding path. A Docker path MUST be complete: services, hostnames, ports, follow-up migrations/builds/workers, and user-facing URLs. Do not advertise Docker merely because a Make target or maintenance file exists.
+
+When Compose supplies only backing services, label it `Docker services` and state that the application or protocol runtime still starts separately. Put it after the local configuration needed to use those services unless it is the recommended first-success path.
+
+Quick start may name the local configuration creation/copy command. The `Configuration` section is the single detailed source for file ownership, ignored status, required values, and container differences. Do not repeat full configuration examples for each runtime unless values materially differ.
+
+State a canonical verification URL or request once in Quick start or the relevant variant section. Do not duplicate route or endpoint inventories across native and Docker paths; describe only host, port, or authentication differences in an alternate path. Move exhaustive routes to focused documentation.
 
 Use `http://localhost:<port>` or `http://127.0.0.1:<port>` for browser instructions. `0.0.0.0` is a bind address, not a reader-facing URL.
 
@@ -58,7 +90,7 @@ Use `http://localhost:<port>` or `http://127.0.0.1:<port>` for browser instructi
 - **Frontend skeletons** MUST state PHP and frontend runtime requirements, dependency installation, watch/build commands, and whether frontend and PHP processes run separately.
 - **MCP/protocol skeletons** MUST describe each transport separately, including its connection URL or STDIO command and required inspector/client workflow.
 - **CMS skeletons** MUST document install/development/build/start commands, local admin/bootstrap behavior, and configuration grouped by subsystem.
-- **Security-focused integrations** MUST state secure defaults and data-sharing or credential implications before opt-in instructions.
+- **Security-focused integrations** MUST state secure defaults, outbound-data boundaries, and credential handling before any opt-in configuration or command that can transmit data or use credentials.
 
 ## Links, visuals, and development
 
@@ -66,7 +98,11 @@ A maintained demo link SHOULD appear near the purpose section when it helps user
 
 Use relative links for repository-owned files and assets. Do not use `blob/master` URLs for local files. Keep architecture, troubleshooting, and exhaustive dependency material in focused documentation when it would obscure onboarding.
 
-Document canonical quality and test commands when the repository provides them. Prefer project entrypoints such as `make qa`, `make tests`, `composer test`, or `npm run test`. Describe commands accurately.
+Use `Commands` or `Development and quality checks` for canonical QA, tests, builds, watchers, migrations, and consumers. Reserve a final `Development` section for contribution, maintenance, and footer material. A generic footer MUST NOT displace operational documentation.
+
+The README MUST keep only information necessary to select the project and reach first success. Put architecture, complete route catalogs, extensive package lists, screenshots, troubleshooting, and deployment detail in `docs/` or `.docs/`, and link to it from `Further documentation`.
+
+Document canonical quality and test commands when the repository provides them. Prefer project entrypoints such as `make qa`, `make tests`, `composer test`, or `npm run test`. Describe commands accurately. A maintained repository MUST provide a contributor route: prefer a repository-local `CONTRIBUTING.md`; otherwise link to applicable maintained organization guidance.
 
 Avoid generic encouragement such as "Open the page and enjoy" without stating the expected route, interaction, or output.
 
@@ -75,7 +111,10 @@ Review before merge:
 - [ ] Project type, audience, and first success are clear.
 - [ ] Requirements, acquisition model, commands, services, ports, and URLs match tracked sources.
 - [ ] The quick-start sequence is complete and one route is clearly recommended.
+- [ ] The recommended route has been run against the current tracked state; record the verification command or CI/smoke-check reference in the pull request when it is not self-evident.
+- [ ] A concrete success signal is stated; alternate paths are correctly distinguished.
 - [ ] Configuration scope, development-only credentials, and security implications are clear.
 - [ ] Docker is complete when documented and omitted when it is not a supported user path.
 - [ ] Variant-specific API, worker, frontend, protocol, CMS, or security rules are covered.
+- [ ] The contributor route and canonical development commands are accurate.
 - [ ] Links and visual assets resolve; Markdown renders correctly on GitHub.

--- a/docs/readme-skeleton-standard.md
+++ b/docs/readme-skeleton-standard.md
@@ -1,0 +1,81 @@
+# Contributte Skeleton README Standard
+
+## Scope
+
+This standard applies to starters, reference applications, demos, and integration projects. A skeleton README is the shortest reliable route from discovery to a verified local success.
+
+## Required information
+
+A skeleton README MUST state whether it is a starter, reference application, demo, or integration demonstration. It MUST give one complete, verified route to a first success:
+
+1. Requirements.
+2. The correct acquisition model.
+3. Dependency installation and local configuration.
+4. Required services, migrations, fixtures, or builds.
+5. Application, API, CLI, or protocol startup.
+6. A URL, request, command output, or client interaction that proves success.
+
+Use this order as a default, omitting irrelevant sections:
+
+```md
+# Project Name
+
+One factual sentence describing the intended use and defining integrations.
+
+## Purpose
+
+## Requirements
+
+## Quick start
+
+## Configuration
+
+## Docker
+
+## Development and quality checks
+
+## Further documentation
+```
+
+The README MUST distinguish acquisition models:
+
+- A consumer-ready starter uses `composer create-project`.
+- A checked-out example or integration uses `composer install`.
+- Document both only when both workflows are supported and their purposes are clear.
+
+## Configuration and runtime paths
+
+Document the minimum configuration needed for the recommended path: config file/environment source, local or gitignored status, values that must change, and values that differ in containers. Label demo credentials as development-only.
+
+Document Docker only when it is a supported or recommended onboarding path. A Docker path MUST be complete: services, hostnames, ports, follow-up migrations/builds/workers, and user-facing URLs. Do not advertise Docker merely because a Make target or maintenance file exists.
+
+Use `http://localhost:<port>` or `http://127.0.0.1:<port>` for browser instructions. `0.0.0.0` is a bind address, not a reader-facing URL.
+
+## Variant-specific additions
+
+- **API skeletons** MUST include the base URL, a health/ping endpoint, an API/OpenAPI discovery endpoint when available, and one copyable successful request. Explain authentication or development tokens.
+- **Worker/DDD skeletons** MUST state backing services, startup order, and consumer/worker commands when central to the example.
+- **Frontend skeletons** MUST state PHP and frontend runtime requirements, dependency installation, watch/build commands, and whether frontend and PHP processes run separately.
+- **MCP/protocol skeletons** MUST describe each transport separately, including its connection URL or STDIO command and required inspector/client workflow.
+- **CMS skeletons** MUST document install/development/build/start commands, local admin/bootstrap behavior, and configuration grouped by subsystem.
+- **Security-focused integrations** MUST state secure defaults and data-sharing or credential implications before opt-in instructions.
+
+## Links, visuals, and development
+
+A maintained demo link SHOULD appear near the purpose section when it helps users choose the project. Screenshots or GIFs MAY be included for UI and protocol workflows, but only when they have meaningful alt text/captions and support the instructions rather than replace them.
+
+Use relative links for repository-owned files and assets. Do not use `blob/master` URLs for local files. Keep architecture, troubleshooting, and exhaustive dependency material in focused documentation when it would obscure onboarding.
+
+Document canonical quality and test commands when the repository provides them. Prefer project entrypoints such as `make qa`, `make tests`, `composer test`, or `npm run test`. Describe commands accurately.
+
+Avoid generic encouragement such as "Open the page and enjoy" without stating the expected route, interaction, or output.
+
+Review before merge:
+
+- [ ] Project type, audience, and first success are clear.
+- [ ] Requirements, acquisition model, commands, services, ports, and URLs match tracked sources.
+- [ ] The quick-start sequence is complete and one route is clearly recommended.
+- [ ] Configuration scope, development-only credentials, and security implications are clear.
+- [ ] Docker is complete when documented and omitted when it is not a supported user path.
+- [ ] Variant-specific API, worker, frontend, protocol, CMS, or security rules are covered.
+- [ ] Links and visual assets resolve; Markdown renders correctly on GitHub.

--- a/docs/readme-standard.md
+++ b/docs/readme-standard.md
@@ -8,6 +8,14 @@ Contributte maintains separate README standards because a reusable library, a ru
 
 The keywords **MUST**, **SHOULD**, and **MAY** describe required, recommended, and optional practices. A repository uses the profile that matches its current maintenance state and intended user journey.
 
+Select the profile by the first supported journey presented to a new reader, not by the repository name or whether it is published on Packagist:
+
+- Use the Library profile when the README's supported first journey is installing the repository as a dependency.
+- Use the Skeleton profile when the README's supported first journey is obtaining or running the repository to start or evaluate an application. Maintained demos and examples use this profile.
+- Use the Deprecated profile for unsupported repositories regardless of their former type.
+
+A repository that supports both dependency installation and a runnable application MUST select one primary profile and link to the other supported journey without duplicating its full instructions.
+
 ## Shared evidence rules
 
 Before editing any README, verify machine facts in tracked sources:

--- a/docs/readme-standard.md
+++ b/docs/readme-standard.md
@@ -1,0 +1,199 @@
+# Contributte README Standard
+
+## Purpose and scope
+
+This standard applies to root `README.md` files in maintained Contributte repositories.
+
+The README is the reliable entry point for a new user or contributor. It explains what a repository is, how to reach a first successful result, and where to find maintained detail. It is not a copy of every configuration reference, changelog, or implementation guide.
+
+Choose the profile that matches the repository:
+
+- **Library**: a reusable Composer package.
+- **Skeleton**: a starter, reference application, demo, or integration project.
+- **Demo or example**: use the closest profile and document only the runnable surface it actually provides.
+
+The keywords **MUST**, **SHOULD**, and **MAY** describe required, recommended, and optional practices.
+
+## Sources of truth
+
+Before editing a README, verify machine facts in tracked executable sources:
+
+- `composer.json`, `package.json`, and lock files for runtime and package requirements;
+- `Makefile`, Composer scripts, and npm scripts for commands;
+- framework configuration and `.env.example` / `config/local.neon.example` for setup;
+- Docker and Compose files for services, ports, hostnames, and credentials;
+- routes, CLI commands, tests, and CI for documented outcomes and quality commands.
+
+The README is authoritative for the supported user journey. Executable configuration is authoritative for machine facts. Detailed local documentation is authoritative for reference material. Do not let two locations make conflicting claims.
+
+## Universal rules
+
+Every README:
+
+- MUST begin with a visible H1 that identifies the project.
+- MUST open with a concise, factual explanation of what it provides and who should use it.
+- MUST use only verified commands, versions, URLs, ports, credentials, service names, and feature claims.
+- MUST keep repository-owned links and assets relative where possible.
+- MUST use typed fenced code blocks such as `bash`, `php`, `neon`, `json`, or `yaml`.
+- MUST clearly mark local/demo credentials and MUST NOT publish real secrets or imply that example credentials are safe in production.
+- SHOULD use direct, concise technical English: "Install", "Create", "Configure", "Run", and "Use".
+- SHOULD keep a first useful action near the top.
+- SHOULD link to focused documentation instead of duplicating exhaustive reference material.
+- MAY include badges, screenshots, demos, support links, maintainers, version matrices, and a table of contents only when they are accurate and maintained.
+
+Do not copy historical boilerplate by default. In particular, tracking images, badge walls, remote screenshot services, stale social links, author-avatar blocks, uncaptioned galleries, and branch-qualified links to local files are not standard requirements.
+
+## Libraries
+
+### Required information
+
+A library README MUST provide:
+
+1. The Composer package name and a copyable installation command.
+2. The primary framework, DI, or runtime integration point when relevant.
+3. A minimal valid use/configuration path, or a direct link to the exact maintained documentation page that contains it.
+4. Compatibility information when consumers must choose between maintained package, PHP, framework, or integration lines.
+5. A contribution or development route when the repository is maintained.
+
+Use the following order as a default, omitting sections that are not useful:
+
+```md
+# Package Name
+
+One factual sentence describing the package and its primary integration.
+
+## Installation
+
+## Quick start
+
+## Documentation
+
+## Supported versions
+
+## Development
+```
+
+Use `Installation` for `composer require`; do not call installation-only content `Usage`. For a development-only package, use `composer require --dev` and say why.
+
+For Nette integrations, the first-use path MUST include the required extension registration or NEON configuration when installation alone does not make the package usable. Do not expose internal service IDs as normal configuration unless they are a documented public extension point.
+
+### Documentation boundary
+
+The concise Contributte library landing page and repository-local `.docs` material are complementary:
+
+- Keep purpose, installation, compatibility, the minimal integration path, and development entrypoints in the root README.
+- Keep exhaustive schemas, API inventories, provider lists, migration history, and long tutorials in focused documentation.
+- Link with a relative path, for example `[Documentation](.docs/)` or a direct topic link.
+
+A small library MAY keep its full manual in the README when that remains the practical canonical documentation and is still navigable.
+
+### Compatibility and examples
+
+State requirements near installation when a support decision is non-obvious. Use a compact matrix only when multiple maintained lines or integrations require it. Matrix values MUST match package constraints, tested CI, and actual release policy.
+
+Each primary example MUST be syntactically valid, focused on one outcome, and introduced with where it belongs. Prefer constructor injection and current project conventions over legacy public-property injection or PHPDoc-heavy pseudo-code.
+
+### Library visuals and badges
+
+Badges are optional. If used, keep them compact and actionable: CI, package version, PHP support, license, or live coverage. Use the actual Packagist package name, which may differ from the repository name. Every image needs useful alternative text.
+
+Images are optional. Include a repository-owned image only when it demonstrates a meaningful UI, CLI, or result. Headless integrations generally need a clear example more than a screenshot.
+
+## Skeletons
+
+### Required information
+
+A skeleton README MUST state whether it is a starter, reference application, demo, or integration demonstration. It MUST give one complete, verified route to a first success:
+
+1. Requirements.
+2. Correct acquisition model.
+3. Dependency installation and local configuration.
+4. Required services, migrations, fixtures, or builds.
+5. Application, API, CLI, or protocol startup.
+6. The browser URL, request, command output, or client interaction that proves success.
+
+Use this default order, omitting irrelevant sections:
+
+```md
+# Project Name
+
+One factual sentence describing the intended use and defining integrations.
+
+## Purpose
+
+## Requirements
+
+## Quick start
+
+## Configuration
+
+## Docker
+
+## Development and quality checks
+
+## Further documentation
+```
+
+The README MUST distinguish the acquisition models:
+
+- A consumer-ready starter uses `composer create-project`.
+- A checked-out example or integration uses `composer install`.
+- Document both only when both workflows are supported and their different purposes are clear.
+
+### Configuration and runtime paths
+
+Document the minimum configuration needed for the recommended path: config file/environment source, local or gitignored status, values that must change, and values that differ in containers. Label demo credentials as development-only.
+
+Document Docker only when it is a supported or recommended onboarding path. A Docker path MUST be complete: services, hostnames, ports, follow-up migrations/builds/workers, and user-facing URLs. Do not advertise Docker merely because a Make target or maintenance file exists.
+
+Use `http://localhost:<port>` or `http://127.0.0.1:<port>` for browser instructions. `0.0.0.0` is a bind address, not a reader-facing URL.
+
+### Variant-specific additions
+
+- **API skeletons** MUST include the base URL, a health/ping endpoint, an API/OpenAPI discovery endpoint when available, and one copyable successful request. Explain authentication or development tokens.
+- **Worker/DDD skeletons** MUST state backing services, startup order, and consumer/worker commands when central to the example.
+- **Frontend skeletons** MUST state PHP and frontend runtime requirements, dependency installation, watch/build commands, and whether frontend and PHP processes run separately.
+- **MCP/protocol skeletons** MUST describe each transport separately, including its connection URL or STDIO command and required inspector/client workflow.
+- **CMS skeletons** MUST document install/development/build/start commands, local admin/bootstrap behavior, and configuration grouped by subsystem.
+- **Security-focused integrations** MUST state secure defaults and data-sharing or credential implications before opt-in instructions.
+
+### Skeleton visuals and tone
+
+A maintained demo link SHOULD appear near the purpose section when it helps users choose the project. Screenshots or GIFs MAY be included for UI and protocol workflows, but only when they have meaningful alt text/captions and support the instructions rather than replace them.
+
+Avoid generic encouragement such as "Open the page and enjoy" without saying what should work. State the expected route, interaction, or output.
+
+## Links, images, and navigation
+
+Use relative links for repository-owned files and assets. Do not use `blob/master` URLs for files in the same repository. Use absolute HTTPS URLs for external resources, canonical hosted documentation, Packagist, and maintained public demos.
+
+Use images only when they communicate information more effectively than text. Store durable assets in the repository, provide useful alt text, and prefer Markdown over complex HTML. Minimal HTML is acceptable for a real rendering need such as image width.
+
+Do not add a manual table of contents to a short README. It MAY be useful when a long README has several independently useful areas and GitHub's outline is insufficient. Keep it shallow and maintain it with the headings.
+
+## Development and maintenance
+
+Document canonical quality and test commands when the repository provides them. Prefer project entrypoints such as `make qa`, `make tests`, `composer test`, or `npm run test` to unverified implementation details. Describe commands accurately; a QA target is not a test target unless it runs tests.
+
+Link to repository-specific contribution guidance when available. Keep maintainer and sponsor information factual, current, and secondary to onboarding.
+
+When a change affects documented installation, configuration, a runtime version, a command, a port, a credential, an endpoint, or an image, update the relevant README and detailed documentation in the same pull request.
+
+## Review checklist
+
+- [ ] The repository profile is correct: library, skeleton, demo, or example.
+- [ ] The opening identifies the project, intended user, and primary outcome.
+- [ ] Commands, requirements, versions, URLs, ports, services, and configuration match tracked sources.
+- [ ] The first-success path is complete for the selected profile.
+- [ ] Configuration scope, local-only values, and secret safety are clear.
+- [ ] README content is onboarding material; detailed documentation has one canonical location.
+- [ ] Local links and images are relative, resolve, and have useful text alternatives where needed.
+- [ ] Badges, visuals, and contact links are relevant, live, and not inherited decoration.
+- [ ] Examples are valid, typed, current, and show public supported interfaces.
+- [ ] Markdown renders correctly on GitHub.
+
+## Exceptions
+
+This standard deliberately avoids a fixed copy/paste template. A repository MAY depart from a MUST when its runtime model makes the rule inapplicable. State the rule, the repository-specific reason, the alternate documentation location, and a review date for temporary exceptions in the pull request description. A maintainer must approve the exception.
+
+Cross-repository exceptions belong in an RFC and require an update to this standard.

--- a/docs/readme-standard.md
+++ b/docs/readme-standard.md
@@ -1,199 +1,28 @@
-# Contributte README Standard
+# Contributte README Standards
 
-## Purpose and scope
+Contributte maintains separate README standards because a reusable library, a runnable skeleton, and a deprecated repository serve different readers.
 
-This standard applies to root `README.md` files in maintained Contributte repositories.
+- [Library README Standard](readme-library-standard.md) for maintained reusable packages.
+- [Skeleton README Standard](readme-skeleton-standard.md) for starters, reference applications, demos, and integration projects.
+- [Deprecated Repository README Standard](readme-deprecated-standard.md) for archived, abandoned, superseded, or otherwise unsupported libraries.
 
-The README is the reliable entry point for a new user or contributor. It explains what a repository is, how to reach a first successful result, and where to find maintained detail. It is not a copy of every configuration reference, changelog, or implementation guide.
+The keywords **MUST**, **SHOULD**, and **MAY** describe required, recommended, and optional practices. A repository uses the profile that matches its current maintenance state and intended user journey.
 
-Choose the profile that matches the repository:
+## Shared evidence rules
 
-- **Library**: a reusable Composer package.
-- **Skeleton**: a starter, reference application, demo, or integration project.
-- **Demo or example**: use the closest profile and document only the runnable surface it actually provides.
+Before editing any README, verify machine facts in tracked sources:
 
-The keywords **MUST**, **SHOULD**, and **MAY** describe required, recommended, and optional practices.
-
-## Sources of truth
-
-Before editing a README, verify machine facts in tracked executable sources:
-
-- `composer.json`, `package.json`, and lock files for runtime and package requirements;
+- `composer.json`, `package.json`, and lock files for requirements and package names;
 - `Makefile`, Composer scripts, and npm scripts for commands;
-- framework configuration and `.env.example` / `config/local.neon.example` for setup;
-- Docker and Compose files for services, ports, hostnames, and credentials;
-- routes, CLI commands, tests, and CI for documented outcomes and quality commands.
+- configuration, routes, Docker/Compose files, and environment templates for setup;
+- tests and CI for supported flows and quality commands.
 
-The README is authoritative for the supported user journey. Executable configuration is authoritative for machine facts. Detailed local documentation is authoritative for reference material. Do not let two locations make conflicting claims.
+The README is authoritative for the supported user journey. Executable configuration is authoritative for machine facts. Detailed documentation is authoritative for reference material. Do not let two locations make conflicting claims.
 
-## Universal rules
-
-Every README:
-
-- MUST begin with a visible H1 that identifies the project.
-- MUST open with a concise, factual explanation of what it provides and who should use it.
-- MUST use only verified commands, versions, URLs, ports, credentials, service names, and feature claims.
-- MUST keep repository-owned links and assets relative where possible.
-- MUST use typed fenced code blocks such as `bash`, `php`, `neon`, `json`, or `yaml`.
-- MUST clearly mark local/demo credentials and MUST NOT publish real secrets or imply that example credentials are safe in production.
-- SHOULD use direct, concise technical English: "Install", "Create", "Configure", "Run", and "Use".
-- SHOULD keep a first useful action near the top.
-- SHOULD link to focused documentation instead of duplicating exhaustive reference material.
-- MAY include badges, screenshots, demos, support links, maintainers, version matrices, and a table of contents only when they are accurate and maintained.
-
-Do not copy historical boilerplate by default. In particular, tracking images, badge walls, remote screenshot services, stale social links, author-avatar blocks, uncaptioned galleries, and branch-qualified links to local files are not standard requirements.
-
-## Libraries
-
-### Required information
-
-A library README MUST provide:
-
-1. The Composer package name and a copyable installation command.
-2. The primary framework, DI, or runtime integration point when relevant.
-3. A minimal valid use/configuration path, or a direct link to the exact maintained documentation page that contains it.
-4. Compatibility information when consumers must choose between maintained package, PHP, framework, or integration lines.
-5. A contribution or development route when the repository is maintained.
-
-Use the following order as a default, omitting sections that are not useful:
-
-```md
-# Package Name
-
-One factual sentence describing the package and its primary integration.
-
-## Installation
-
-## Quick start
-
-## Documentation
-
-## Supported versions
-
-## Development
-```
-
-Use `Installation` for `composer require`; do not call installation-only content `Usage`. For a development-only package, use `composer require --dev` and say why.
-
-For Nette integrations, the first-use path MUST include the required extension registration or NEON configuration when installation alone does not make the package usable. Do not expose internal service IDs as normal configuration unless they are a documented public extension point.
-
-### Documentation boundary
-
-The concise Contributte library landing page and repository-local `.docs` material are complementary:
-
-- Keep purpose, installation, compatibility, the minimal integration path, and development entrypoints in the root README.
-- Keep exhaustive schemas, API inventories, provider lists, migration history, and long tutorials in focused documentation.
-- Link with a relative path, for example `[Documentation](.docs/)` or a direct topic link.
-
-A small library MAY keep its full manual in the README when that remains the practical canonical documentation and is still navigable.
-
-### Compatibility and examples
-
-State requirements near installation when a support decision is non-obvious. Use a compact matrix only when multiple maintained lines or integrations require it. Matrix values MUST match package constraints, tested CI, and actual release policy.
-
-Each primary example MUST be syntactically valid, focused on one outcome, and introduced with where it belongs. Prefer constructor injection and current project conventions over legacy public-property injection or PHPDoc-heavy pseudo-code.
-
-### Library visuals and badges
-
-Badges are optional. If used, keep them compact and actionable: CI, package version, PHP support, license, or live coverage. Use the actual Packagist package name, which may differ from the repository name. Every image needs useful alternative text.
-
-Images are optional. Include a repository-owned image only when it demonstrates a meaningful UI, CLI, or result. Headless integrations generally need a clear example more than a screenshot.
-
-## Skeletons
-
-### Required information
-
-A skeleton README MUST state whether it is a starter, reference application, demo, or integration demonstration. It MUST give one complete, verified route to a first success:
-
-1. Requirements.
-2. Correct acquisition model.
-3. Dependency installation and local configuration.
-4. Required services, migrations, fixtures, or builds.
-5. Application, API, CLI, or protocol startup.
-6. The browser URL, request, command output, or client interaction that proves success.
-
-Use this default order, omitting irrelevant sections:
-
-```md
-# Project Name
-
-One factual sentence describing the intended use and defining integrations.
-
-## Purpose
-
-## Requirements
-
-## Quick start
-
-## Configuration
-
-## Docker
-
-## Development and quality checks
-
-## Further documentation
-```
-
-The README MUST distinguish the acquisition models:
-
-- A consumer-ready starter uses `composer create-project`.
-- A checked-out example or integration uses `composer install`.
-- Document both only when both workflows are supported and their different purposes are clear.
-
-### Configuration and runtime paths
-
-Document the minimum configuration needed for the recommended path: config file/environment source, local or gitignored status, values that must change, and values that differ in containers. Label demo credentials as development-only.
-
-Document Docker only when it is a supported or recommended onboarding path. A Docker path MUST be complete: services, hostnames, ports, follow-up migrations/builds/workers, and user-facing URLs. Do not advertise Docker merely because a Make target or maintenance file exists.
-
-Use `http://localhost:<port>` or `http://127.0.0.1:<port>` for browser instructions. `0.0.0.0` is a bind address, not a reader-facing URL.
-
-### Variant-specific additions
-
-- **API skeletons** MUST include the base URL, a health/ping endpoint, an API/OpenAPI discovery endpoint when available, and one copyable successful request. Explain authentication or development tokens.
-- **Worker/DDD skeletons** MUST state backing services, startup order, and consumer/worker commands when central to the example.
-- **Frontend skeletons** MUST state PHP and frontend runtime requirements, dependency installation, watch/build commands, and whether frontend and PHP processes run separately.
-- **MCP/protocol skeletons** MUST describe each transport separately, including its connection URL or STDIO command and required inspector/client workflow.
-- **CMS skeletons** MUST document install/development/build/start commands, local admin/bootstrap behavior, and configuration grouped by subsystem.
-- **Security-focused integrations** MUST state secure defaults and data-sharing or credential implications before opt-in instructions.
-
-### Skeleton visuals and tone
-
-A maintained demo link SHOULD appear near the purpose section when it helps users choose the project. Screenshots or GIFs MAY be included for UI and protocol workflows, but only when they have meaningful alt text/captions and support the instructions rather than replace them.
-
-Avoid generic encouragement such as "Open the page and enjoy" without saying what should work. State the expected route, interaction, or output.
-
-## Links, images, and navigation
-
-Use relative links for repository-owned files and assets. Do not use `blob/master` URLs for files in the same repository. Use absolute HTTPS URLs for external resources, canonical hosted documentation, Packagist, and maintained public demos.
-
-Use images only when they communicate information more effectively than text. Store durable assets in the repository, provide useful alt text, and prefer Markdown over complex HTML. Minimal HTML is acceptable for a real rendering need such as image width.
-
-Do not add a manual table of contents to a short README. It MAY be useful when a long README has several independently useful areas and GitHub's outline is insufficient. Keep it shallow and maintain it with the headings.
-
-## Development and maintenance
-
-Document canonical quality and test commands when the repository provides them. Prefer project entrypoints such as `make qa`, `make tests`, `composer test`, or `npm run test` to unverified implementation details. Describe commands accurately; a QA target is not a test target unless it runs tests.
-
-Link to repository-specific contribution guidance when available. Keep maintainer and sponsor information factual, current, and secondary to onboarding.
-
-When a change affects documented installation, configuration, a runtime version, a command, a port, a credential, an endpoint, or an image, update the relevant README and detailed documentation in the same pull request.
-
-## Review checklist
-
-- [ ] The repository profile is correct: library, skeleton, demo, or example.
-- [ ] The opening identifies the project, intended user, and primary outcome.
-- [ ] Commands, requirements, versions, URLs, ports, services, and configuration match tracked sources.
-- [ ] The first-success path is complete for the selected profile.
-- [ ] Configuration scope, local-only values, and secret safety are clear.
-- [ ] README content is onboarding material; detailed documentation has one canonical location.
-- [ ] Local links and images are relative, resolve, and have useful text alternatives where needed.
-- [ ] Badges, visuals, and contact links are relevant, live, and not inherited decoration.
-- [ ] Examples are valid, typed, current, and show public supported interfaces.
-- [ ] Markdown renders correctly on GitHub.
+All profiles require clear technical English, typed code fences, relative repository links where possible, and no real secrets. Do not copy historical boilerplate by default: tracking images, badge walls, remote screenshot services, stale social links, author-avatar blocks, and branch-qualified links to local files are never required.
 
 ## Exceptions
 
-This standard deliberately avoids a fixed copy/paste template. A repository MAY depart from a MUST when its runtime model makes the rule inapplicable. State the rule, the repository-specific reason, the alternate documentation location, and a review date for temporary exceptions in the pull request description. A maintainer must approve the exception.
+The standards describe outcomes, not copy/paste templates. A repository MAY depart from a MUST when its runtime model or maintenance state makes the rule inapplicable. Explain the rule, repository-specific reason, alternate documentation location, and review date for temporary exceptions in the pull request description. A maintainer must approve the exception.
 
-Cross-repository exceptions belong in an RFC and require an update to this standard.
+Cross-repository exceptions require an RFC and an update to the relevant standard.


### PR DESCRIPTION
## What changed

Adds profile-based README standards for Contributte repositories:

- `docs/readme-library-standard.md` for maintained reusable Composer packages
- `docs/readme-skeleton-standard.md` for starters, reference applications, demos, and integration projects
- `docs/readme-deprecated-standard.md` for archived, abandoned, superseded, or unsupported repositories
- `docs/readme-standard.md` as the shared index, evidence rules, and exception process

## Why

Libraries, runnable skeletons, and deprecated repositories serve different readers. Separate standards prevent a generic template from producing inaccurate onboarding or misleading support claims.

The rules are based on analysis of current Contributte README patterns, repository configuration, and GitHub Markdown guidance.

## Checks

- `git diff --check`
- Reviewed document links and profile scope